### PR TITLE
Fix startup message, LGPL -> GPL

### DIFF
--- a/src/freemail/Freemail.java
+++ b/src/freemail/Freemail.java
@@ -167,7 +167,7 @@ public abstract class Freemail implements ConfigClient {
 	
 	protected void startWorkers(boolean daemon) {
 		System.out.println("This is Freemail version "+getVersionString());
-		System.out.println("Freemail is released under the terms of the GNU Lesser General Public License. Freemail is provided WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. For details, see the LICENSE file included with this distribution.");
+		System.out.println("Freemail is released under the terms of the GNU General Public License. Freemail is provided WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. For details, see the LICENSE file included with this distribution.");
 		System.out.println("");
 		
 		// start a SingleAccountWatcher for each account


### PR DESCRIPTION
Changes the startup message so it says that Freemail is GPL, not LGPL
