### PR TITLE
Fix parsing of email addresses

### DIFF
--- a/src/freemail/utils/EmailAddress.java
+++ b/src/freemail/utils/EmailAddress.java
@@ -73,14 +73,16 @@ public class EmailAddress {
 		}
 		
 		// trim quotes out of the real name field
-		if (realname != null && realname.length() > 0) {
-		    this.realname = this.realname.trim();
-		    if (this.realname.charAt(0) == '\"') {
-			this.realname = this.realname.substring(1);
-		    }
-		    if (this.realname.charAt(this.realname.length() - 1) == '\"') {
-			this.realname = this.realname.substring(0, this.realname.length() - 1);
-		    }
+		if (realname != null) {
+			this.realname = this.realname.trim();
+
+			if((this.realname.length() > 0) && (this.realname.charAt(0) == '\"')) {
+				this.realname = this.realname.substring(1);
+			}
+
+			if((this.realname.length() > 0) && (this.realname.charAt(this.realname.length() - 1) == '\"')) {
+				this.realname = this.realname.substring(0, this.realname.length() - 1);
+			}
 		}
 	}
 	


### PR DESCRIPTION
Check realname length at each step since it changes. This fixes the crash that occurred when parsing some addresses.

Fixes bug 5102
