### PR TITLE
Rewrite the locking in HighLevelFCPClient

### DIFF
--- a/src/freemail/fcp/HighLevelFCPClient.java
+++ b/src/freemail/fcp/HighLevelFCPClient.java
@@ -182,7 +182,7 @@ public class HighLevelFCPClient implements FCPClient {
 					return new FCPPutFailedException(FCPPutFailedException.TIMEOUT, false);
 				}
 				try {
-					this.wait(30000);
+					donemsgLock.wait(30000);
 				} catch (InterruptedException ie) {
 				}
 			}


### PR DESCRIPTION
The previous locking scheme wasn't thread safe since it used this as the
only lock, while also wait()ing on it. The new version uses this for
making sure that only one request is in progress at any given time, and
donemsgLock for wait/notify/synchronization of the result of that one
request.
