### PR TITLE
Fix build failure due to missing ant target.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -111,7 +111,7 @@
 		</copy>
 	</target>
 
-	<target name="compile-tools" depends="bouncycastle-fetch"
+	<target name="compile-tools" 
 	        description="Compiles the supporting tools">
 		<mkdir dir="${tools.dst}"/>
 


### PR DESCRIPTION
Seemingly due to the combination of bcd5da2f017772c581db4b60e53447da4676d8e8 and e65db06ab54fc92a8ce41a46f1818b29a8a7c165 and merging problems.
