### PR TITLE
Use correct label for SMTP address.

### DIFF
--- a/src/org/freenetproject/freemail/ui/web/InfoToadlet.java
+++ b/src/org/freenetproject/freemail/ui/web/InfoToadlet.java
@@ -73,7 +73,7 @@ class InfoToadlet extends WebPage {
 				config.get(Configurator.IMAP_BIND_ADDRESS), "imapAddr");
 		addInfoLine(serverBox, FreemailL10n.getString("Freemail.InfoToadlet.imap-port.title"),
 				config.get(Configurator.IMAP_BIND_PORT), "imapPort");
-		addInfoLine(serverBox, FreemailL10n.getString("Freemail.InfoToadlet.imap-addr.title"),
+		addInfoLine(serverBox, FreemailL10n.getString("Freemail.InfoToadlet.smtp-addr.title"),
 				config.get(Configurator.SMTP_BIND_ADDRESS), "imapPort");
 		addInfoLine(serverBox, FreemailL10n.getString("Freemail.InfoToadlet.smtp-port.title"),
 				config.get(Configurator.SMTP_BIND_PORT), "smtpPort");


### PR DESCRIPTION
The line with the SMTP server address shows the wrong label.
