### PR TITLE
Automatically disconnect after 30 minutes.

### DIFF
--- a/src/org/freenetproject/freemail/imap/IMAPHandler.java
+++ b/src/org/freenetproject/freemail/imap/IMAPHandler.java
@@ -44,6 +44,7 @@ import java.util.TreeSet;
 import java.lang.NumberFormatException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import org.archive.util.Base32;
 import org.freenetproject.freemail.AccountManager;
@@ -78,7 +79,7 @@ public class IMAPHandler extends ServerHandler implements Runnable {
 		this.sendWelcome();
 
 		try {
-			client.setSoTimeout(5000);
+			client.setSoTimeout((int) TimeUnit.MINUTES.toMillis(30));
 		} catch (SocketException se1) {
 			Logger.warning(this, "Could not set timeout on client socket!", se1);
 		}
@@ -96,6 +97,9 @@ public class IMAPHandler extends ServerHandler implements Runnable {
 				} catch (IMAPBadMessageException bme) {
 					continue;
 				} catch (SocketTimeoutException ste1) {
+					sendState("BYE Automatically disconnected, too much idleness");
+					ps.flush();
+					stopping = true;
 					continue;
 				}
 			}


### PR DESCRIPTION
I have a couple of Freemail accounts, and Freemail over the time of days started collecting more and more threads, all hanging in the readLine() method in the IMAPHandler. Stepping through the code in a debugger showed that the VM thought that all those sockets it was reading from were still connected. However, both operating systems (the one my node runs on and the one my mail client runs on) were in agreement that the actual number of connections was way smaller.

Now an IMAP handler thread disconnects after a 30 minute timeout, and the problem has not reappeared since.