### PR TITLE
Set thread names for IMAP and SMTP handlers

### DIFF
--- a/src/org/freenetproject/freemail/imap/IMAPListener.java
+++ b/src/org/freenetproject/freemail/imap/IMAPListener.java
@@ -23,6 +23,7 @@ package org.freenetproject.freemail.imap;
 
 import java.net.ServerSocket;
 import java.net.InetAddress;
+import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.io.IOException;
 
@@ -68,8 +69,9 @@ public class IMAPListener extends ServerListener implements Runnable, ConfigClie
 		sock.setSoTimeout(60000);
 		while(!sock.isClosed()) {
 			try {
-				IMAPHandler newcli = new IMAPHandler(accountManager, sock.accept());
-				Thread newthread = new Thread(newcli);
+				Socket clientSocket = sock.accept();
+				IMAPHandler newcli = new IMAPHandler(accountManager, clientSocket);
+				Thread newthread = new Thread(newcli, "Freemail IMAP Handler for " + clientSocket.getInetAddress());
 				newthread.setDaemon(true);
 				newthread.start();
 				addHandler(newcli, newthread);

--- a/src/org/freenetproject/freemail/smtp/SMTPListener.java
+++ b/src/org/freenetproject/freemail/smtp/SMTPListener.java
@@ -24,6 +24,7 @@ package org.freenetproject.freemail.smtp;
 import java.net.ServerSocket;
 import java.net.InetAddress;
 import java.io.IOException;
+import java.net.Socket;
 
 import org.freenetproject.freemail.AccountManager;
 import org.freenetproject.freemail.Freemail;
@@ -71,8 +72,9 @@ public class SMTPListener extends ServerListener implements Runnable, ConfigClie
 		while(!sock.isClosed()) {
 			try {
 				IdentityMatcher matcher = new IdentityMatcher(freemail.getWotConnection());
-				SMTPHandler newcli = new SMTPHandler(accountManager, sock.accept(), matcher);
-				Thread newthread = new Thread(newcli);
+				Socket clientSocket = sock.accept();
+				SMTPHandler newcli = new SMTPHandler(accountManager, clientSocket, matcher);
+				Thread newthread = new Thread(newcli, "Freemail SMTP Handler for " + clientSocket.getInetAddress());
 				newthread.setDaemon(true);
 				newthread.start();
 				addHandler(newcli, newthread);


### PR DESCRIPTION
This does what the title says; it sets thread names on the IMAP and STMP handlers so that they show up properly in the web interface.