### PR TITLE
fix situation when we have in sending message both known and unknown …

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Changes from version 0.2.7.3-r2 to version 0.2.7.4
+
+  o Bugfixes:
+    - Send emails to known IDs in WoT when missing ISs are also present
+
 Changes from version 0.2.7.1 to version 0.2.7.2
 
   o Translation:

--- a/src/org/freenetproject/freemail/ui/web/NewMessageToadlet.java
+++ b/src/org/freenetproject/freemail/ui/web/NewMessageToadlet.java
@@ -267,26 +267,33 @@ public class NewMessageToadlet extends WebPage {
 
 		//Check if there were any unknown or ambiguous identities
 		List<String> failedRecipients = new LinkedList<String>();
+		List<Identity> knownRecipients = new LinkedList<Identity>();
 		for(Map.Entry<String, List<Identity>> entry : matches.entrySet()) {
-			if(entry.getValue().size() != 1) {
+			if(entry.getValue().size() == 1)
+				knownRecipients.add(entry.getValue().get(0));
+			else
 				failedRecipients.add(entry.getKey());
-			}
 		}
 
-		if(failedRecipients.size() != 0) {
-			//TODO: Handle this properly
-			HTMLNode pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.outer;
+		HTMLNode contentNode = page.content;
 
-			HTMLNode errorBox = addErrorbox(contentNode, FreemailL10n.getString("Freemail.NewMessageToadlet.ambigiousIdentitiesTitle"));
-			HTMLNode errorPara = errorBox.addChild("p", FreemailL10n.getString("Freemail.NewMessageToadlet.ambigiousIdentities", "count", "" + failedRecipients.size()));
+		if(!failedRecipients.isEmpty()) {
+			HTMLNode errorBox = addErrorbox(contentNode,
+				 FreemailL10n.getString("Freemail.NewMessageToadlet.ambigiousIdentitiesTitle"));
+			HTMLNode errorPara = errorBox.addChild("p",
+				 FreemailL10n.getString("Freemail.NewMessageToadlet.ambigiousIdentities",
+						"count", "" + failedRecipients.size()));
 			HTMLNode identityList = errorPara.addChild("ul");
 			for(String s : failedRecipients) {
 				identityList.addChild("li", s);
 			}
 
-			sendMessageTimer.log(this, 1, TimeUnit.SECONDS, "Time spent sending message (with failed recipient)");
-			return new GenericHTMLResponse(ctx, 200, "OK", pageNode.generate());
+			sendMessageTimer.log(this, 1, TimeUnit.SECONDS,
+				 "Time spent sending message (with failed recipient)");
+
+			if (knownRecipients.isEmpty())
+				return new GenericHTMLResponse(ctx, 200, "OK", pageNode.generate());
 		}
 
 		//Build message header
@@ -335,19 +342,10 @@ public class NewMessageToadlet extends WebPage {
 		BucketTools.copyTo(messageText, new MailMessage.EncodingOutputStream(messageOutputStream), -1);
 		messageOutputStream.close();
 
-		List<Identity> identities = new LinkedList<Identity>();
-		for(List<Identity> identityList : matches.values()) {
-			assert (identityList.size() == 1);
-			identities.add(identityList.get(0));
-		}
-
 		copyMessageToSentFolder(message, account.getMessageBank());
 
-		account.getMessageHandler().sendMessage(identities, message);
+		account.getMessageHandler().sendMessage(knownRecipients, message);
 		message.free();
-
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
 
 		HTMLNode infobox = addInfobox(contentNode, FreemailL10n.getString("Freemail.NewMessageToadlet.messageQueuedTitle"));
 		infobox.addChild("p", FreemailL10n.getString("Freemail.NewMessageToadlet.messageQueued"));


### PR DESCRIPTION
…IDs in Wot

I found out that if any of recipient IDs is missing in WoT then mail
message is not sent at all. And I have changed the behavior for
sending message to recipients with correct IDs and show info about
recipients with missing ID in WoT.